### PR TITLE
Performing a Peer Review duplicate entry fix

### DIFF
--- a/docs/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy/Pull-Requests.md
+++ b/docs/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy/Pull-Requests.md
@@ -1,5 +1,5 @@
 ---
-title: Performing a Peer Review
+title: Pull Requests
 authors: 
   - Dave Arthur
   - Rhodri Hewitson


### PR DESCRIPTION
Currently there is a duplicate "Performing a Peer Review" selection under 6. Engineering/Peer-reviewing/
This section contained information about creating Pull Requests, I'd thought that be more relevant to the Source control section so I moved it there. 